### PR TITLE
This fix SMTP client connection for servers not using auth

### DIFF
--- a/src/notify.ts
+++ b/src/notify.ts
@@ -141,10 +141,12 @@ export class Notify {
         host: Config.smtpHost,
         port: Number.parseInt(Config.smtpPort),
         secure: Config.smtpTls,
-        auth: {
-          user: Config.smtpUser,
-          pass: Config.smtpPassword
-        }
+        auth: Config.smtpUser
+          ? {
+              user: Config.smtpUser,
+              pass: Config.smtpPassword
+            }
+          : undefined
       });
 
       Log.verbose('✔️ SMTP client created successfully.');


### PR DESCRIPTION
I have a scenario that my local SMTP (behind a firewall in my local network) does not use any sort of authentication, so I don' t have a user and password to provide. I noticed the code was failing because it was not able to handle empty values for user and password, so this fix that behavior. It will only define the "auth" property if the username is provided. 
I tested the change with and without authentication and looks to be working fine, hope you can accept the pull request. 
Thanks!