### PR TITLE
Revert "fix: bump fetch-cookie from 2.2.0 to 3.0.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@honeybadger-io/js": "^6.8.3",
     "@sentry/node": "^7.102.1",
     "chalk": "^4.1.2",
-    "fetch-cookie": "^3.0.1",
+    "fetch-cookie": "^2.2.0",
     "node-fetch": "^3.3.2",
     "node-html-parser": "^6.1.12",
     "nodemailer": "^6.9.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2257,10 +2257,10 @@ fetch-blob@^3.1.2, fetch-blob@^3.1.4:
     node-domexception "^1.0.0"
     web-streams-polyfill "^3.0.3"
 
-fetch-cookie@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/fetch-cookie/-/fetch-cookie-3.0.1.tgz#6a77f7495e1a639ae019db916a234db8c85d5963"
-  integrity sha512-ZGXe8Y5Z/1FWqQ9q/CrJhkUD73DyBU9VF0hBQmEO/wPHe4A9PKTjplFDLeFX8aOsYypZUcX5Ji/eByn3VCVO3Q==
+fetch-cookie@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/fetch-cookie/-/fetch-cookie-2.2.0.tgz#01086b6b5b1c3e08f15ffd8647b02ca100377365"
+  integrity sha512-h9AgfjURuCgA2+2ISl8GbavpUdR+WGAM2McW/ovn4tVccegp8ZqCKWSBR8uRdM8dDNlx5WdKRWxBYUwteLDCNQ==
   dependencies:
     set-cookie-parser "^2.4.8"
     tough-cookie "^4.0.0"


### PR DESCRIPTION
Reverts mattwebbio/orbital-sync#245

Seems to have breaking changes that for some reason didn't break tests