### PR TITLE
Add Docker Secrets support

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -8,6 +8,8 @@
 
 # Orbital Sync: Configuration
 
+See [additional notes](#additional-notes) at the bottom for information such as how to use [Docker secrets](#docker-secrets).
+
 <!-- START CONFIG DOCS -->
 
 | Environment Variable | Required | Default | Example                                                         | Description                                                                                                                                                          |
@@ -96,3 +98,30 @@ Log exceptions to [Honeybadger](https://www.honeybadger.io) or [Sentry](http://s
 | `NOTIFY_EXCEPTIONS_SENTRY_DSN`          | No       | N/A     | `https://key@o0.ingest.sentry.io/0` | Set to use Sentry for proper exception recording; mostly useful for development or debugging.      |
 
 <!-- END CONFIG DOCS -->
+
+# Additional Notes
+
+## Docker Secrets
+
+All above configuration options can be set with Docker secrets. In other words, by appending any environment variable with the `_FILE` suffix, you can provide the path to a file that contains the value. For example, `PRIMARY_HOST_PASSWORD_FILE=/run/secrets/pihole_password` would read the primary host password from the file `/run/secrets/pihole_password`. In practice, a `docker-compose.yml` for this configuration might look like:
+
+```yaml
+services:
+  orbital-sync:
+    image: mattwebbio/orbital-sync:latest
+    secrets:
+      - pihole1_password
+      - pihole2_password
+    environment:
+      - PRIMARY_HOST_BASE_URL=https://pihole1.mydomain.com
+      - PRIMARY_HOST_PASSWORD_FILE=/run/secrets/pihole1_password
+      - SECONDARY_HOSTS_1_BASE_URL=https://pihole2.mydomain.com
+      - SECONDARY_HOSTS_1_PASSWORD_FILE=/run/secrets/pihole2_password
+secrets:
+  pihole1_password:
+    external: true
+  pihole2_password:
+    external: true
+```
+
+If both the `_FILE` and non-`_FILE` versions of an environment variable are set, the `_FILE` version will take precedence.

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "markdown-table": "3",
     "nock": "^13.5.4",
     "prettier": "^3.2.5",
+    "tempy": "^3.1.0",
     "testcontainers": "^10.7.2",
     "ts-jest": "^29.1.2",
     "ts-node": "^10.9.2",

--- a/src/config/parse.ts
+++ b/src/config/parse.ts
@@ -3,6 +3,7 @@
 import mustache from 'mustache';
 import { FromSchema } from 'json-schema-to-ts';
 import type { JSONSchema } from 'json-schema-to-ts';
+import { readFileSync } from 'fs';
 import { camelToSnakeCase } from '../util/string-case.js';
 
 /*
@@ -82,7 +83,12 @@ export function parseSchema<T extends SchemaType>(
 
     return object;
   } else {
-    let value: any = overrides;
+    let value: any;
+    const secretFile = process.env[`${pathToEnvVar(path)}_FILE`];
+
+    if (secretFile)
+      value ??= readFileSync(process.env[`${pathToEnvVar(path)}_FILE`], 'utf8').trim();
+    value ??= overrides;
     value ??= process.env[pathToEnvVar(path)];
     if (schema.envVar) value ??= process.env[schema.envVar];
     value ??= schema.default;

--- a/test/unit/config/index.test.ts
+++ b/test/unit/config/index.test.ts
@@ -1,3 +1,5 @@
+import { writeFile } from 'node:fs/promises';
+import { temporaryFile } from 'tempy';
 import { Config } from '../../../src/config/index';
 
 describe('Config', () => {
@@ -24,6 +26,71 @@ describe('Config', () => {
         {
           baseUrl: 'http://localhost:3001',
           password: 'password'
+        }
+      ],
+      sync: {
+        v5: {
+          adList: true,
+          auditLog: false,
+          blacklist: true,
+          client: true,
+          flushTables: true,
+          group: true,
+          localCnameRecords: true,
+          localDnsRecords: true,
+          regexList: true,
+          regexWhitelist: true,
+          staticDhcpLeases: false,
+          whitelist: true
+        }
+      },
+      notify: {
+        exceptions: {
+          honeybadgerApiKey: undefined,
+          sentryDsn: undefined
+        },
+        onFailure: true,
+        onSuccess: false,
+        smtp: {
+          enabled: false,
+          from: undefined,
+          host: undefined,
+          password: undefined,
+          port: undefined,
+          tls: false,
+          to: undefined,
+          user: undefined
+        }
+      },
+      intervalMinutes: 60,
+      runOnce: false,
+      updateGravity: true,
+      verbose: false
+    });
+  });
+
+  it('should read passwords from files', async () => {
+    const passwordFile1 = temporaryFile();
+    await writeFile(passwordFile1, 'password_from_file_1', 'utf-8');
+    const passwordFile2 = temporaryFile();
+    await writeFile(passwordFile2, 'password_from_file_2\n', 'utf-8');
+
+    process.env['PRIMARY_HOST_BASE_URL'] = 'http://localhost:3000';
+    process.env['PRIMARY_HOST_PASSWORD_FILE'] = passwordFile1;
+
+    process.env['SECONDARY_HOSTS_1_BASE_URL'] = 'http://localhost:3001';
+    process.env['SECONDARY_HOSTS_1_PASSWORD_FILE'] = passwordFile2;
+
+    const config = Config();
+    expect(config).toEqual({
+      primaryHost: {
+        baseUrl: 'http://localhost:3000',
+        password: 'password_from_file_1'
+      },
+      secondaryHosts: [
+        {
+          baseUrl: 'http://localhost:3001',
+          password: 'password_from_file_2'
         }
       ],
       sync: {

--- a/test/unit/config/parse.test.ts
+++ b/test/unit/config/parse.test.ts
@@ -1,5 +1,7 @@
-import { parseSchema } from '../../../src/config/parse';
 import { asConst } from 'json-schema-to-ts';
+import { writeFile } from 'node:fs/promises';
+import { temporaryFile } from 'tempy';
+import { parseSchema } from '../../../src/config/parse';
 
 describe('Config', () => {
   describe('parseSchema', () => {
@@ -325,6 +327,37 @@ describe('Config', () => {
             })
           )
         ).toThrow('Undefined object properties for root');
+      });
+    });
+
+    describe('string', () => {
+      test('should read config values from a file', async () => {
+        const file = temporaryFile();
+        await writeFile(file, 'mock_value_from_file', 'utf-8');
+
+        process.env['VAR_ONE_FILE'] = file;
+        process.env['VAR_ONE'] = 'mock_value_1';
+        process.env['VAR_TWO'] = 'mock_value_2';
+
+        const parsed = parseSchema(
+          asConst({
+            type: 'object',
+            properties: {
+              varOne: {
+                type: 'string'
+              },
+              varTwo: {
+                type: 'string'
+              }
+            },
+            required: ['varOne']
+          })
+        );
+
+        expect(parsed).toEqual({
+          varOne: 'mock_value_from_file',
+          varTwo: 'mock_value_2'
+        });
       });
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1933,6 +1933,13 @@ cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+crypto-random-string@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-4.0.0.tgz#5a3cc53d7dd86183df5da0312816ceeeb5bb1fc2"
+  integrity sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==
+  dependencies:
+    type-fest "^1.0.1"
+
 css-select@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-5.1.0.tgz#b8ebd6554c3637ccc76688804ad3f6a6fdaea8a6"
@@ -4198,6 +4205,21 @@ tar-stream@^3.1.5:
     fast-fifo "^1.2.0"
     streamx "^2.15.0"
 
+temp-dir@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-3.0.0.tgz#7f147b42ee41234cc6ba3138cd8e8aa2302acffa"
+  integrity sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==
+
+tempy@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/tempy/-/tempy-3.1.0.tgz#00958b6df85db8589cb595465e691852aac038e9"
+  integrity sha512-7jDLIdD2Zp0bDe5r3D2qtkd1QOCacylBuL7oa4udvN6v2pqr4+LcCr67C8DR1zkpaZ8XosF5m1yQSabKAW6f2g==
+  dependencies:
+    is-stream "^3.0.0"
+    temp-dir "^3.0.0"
+    type-fest "^2.12.2"
+    unique-string "^3.0.0"
+
 test-exclude@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-6.0.0.tgz#04a8698661d805ea6fa293b6cb9e63ac044ef15e"
@@ -4364,6 +4386,16 @@ type-fest@^0.7.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.7.1.tgz#8dda65feaf03ed78f0a3f9678f1869147f7c5c48"
   integrity sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==
 
+type-fest@^1.0.1:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.4.0.tgz#e9fb813fe3bf1744ec359d55d1affefa76f14be1"
+  integrity sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==
+
+type-fest@^2.12.2:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
+  integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
+
 typescript@^5.4.2:
   version "5.4.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.2.tgz#0ae9cebcfae970718474fe0da2c090cad6577372"
@@ -4378,6 +4410,13 @@ unicorn-magic@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/unicorn-magic/-/unicorn-magic-0.1.0.tgz#1bb9a51c823aaf9d73a8bfcd3d1a23dde94b0ce4"
   integrity sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==
+
+unique-string@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-3.0.0.tgz#84a1c377aff5fd7a8bc6b55d8244b2bd90d75b9a"
+  integrity sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==
+  dependencies:
+    crypto-random-string "^4.0.0"
 
 universalify@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
This pull request adds support for Docker secrets by adding a `_FILE` suffix to all available environment variable configuration options. In other words, when looking at the [configuration docs](https://orbitalsync.com/CONFIG.html#primary-host) we see `PRIMARY_HOST_PASSWORD` and `SECONDARY_HOSTS_1_PASSWORD`. To have these values read from a file, we may set the `PRIMARY_HOST_PASSWORD_FILE` and `SECONDARY_HOSTS_1_PASSWORD_FILE` to paths containing their respective desired values.

Closes https://github.com/mattwebbio/orbital-sync/issues/27