### PR TITLE
Fix error "Not authorized" when uploading archives

### DIFF
--- a/src/client/v5/index.ts
+++ b/src/client/v5/index.ts
@@ -39,7 +39,7 @@ export class ClientV5 {
       headers: {
         'content-type': 'application/x-www-form-urlencoded'
       },
-      body: `pw=${encodeURIComponent(host.password)}&persistentlogin=off`,
+      body: `pw=${encodeURIComponent(host.password)}`,
       method: 'POST'
     });
     if (response.status !== 200)


### PR DESCRIPTION
The `persistentlogin=off` snippet in the request makes the server to respond the cookie `persistentlogin`, which will then be send in the POST `teleporter.php` request when uploading backup, which will cause the pihole server to respond: "Not authorized" when this cookie is sent.

Removing this snippet in the login request removes the `persistentlogin` in the response. Conesquently, the archive upload is accepted by the pihole sever.


=====

When using orbital-sync, I have the following logs:

```
pihole-sync  | 6/30/2024, 8:58:04 AM: ➡️   Signing in to https://example.com/admin...
 ihole-sync  | 6/30/2024, 8:58:04 AM: ✔️   Successfully signed in to https://example.com/admin!
 ihole-sync  | 6/30/2024, 8:58:04 AM: ➡️   Downloading backup from https://example.com/admin...
 ihole-sync  | 6/30/2024, 8:58:04 AM: ✔️   Backup from https://example.com/admin completed!
 ihole-sync  | 6/30/2024, 8:58:04 AM: ➡️   Signing in to https://example.com/admin...
 ihole-sync  | 6/30/2024, 8:58:04 AM: ➡️   Signing in to https://example.com/admin...
 ihole-sync  | 6/30/2024, 8:58:04 AM: ➡️   Signing in to https://example.com/admin...
 ihole-sync  | 6/30/2024, 8:58:04 AM: ✔️   Successfully signed in to https://example.com/admin!
 ihole-sync  | 6/30/2024, 8:58:04 AM: ➡️   Uploading backup to https://example.com/admin...
 ihole-sync  | 6/30/2024, 8:58:04 AM: {"host":"https://example.com","path":"/admin","status":200,"responseBody":"Not authorized"}
pihole-sync  | 6/30/2024, 8:58:04 AM: ⚠ Error: Failed to upload backup to "https://example.com/admin".
pihole-sync  | 6/30/2024, 8:58:04 AM: ✔️   Successfully signed in to https://example.com/admin!
 ihole-sync  | 6/30/2024, 8:58:04 AM: ➡️   Uploading backup to https://example.com/admin...
 ihole-sync  | 6/30/2024, 8:58:04 AM: {"host":"https://example.com","path":"/admin","status":200,"responseBody":"Not authorized"}
pihole-sync  | 6/30/2024, 8:58:04 AM: ⚠ Error: Failed to upload backup to "https://example.com/admin".
pihole-sync  | 6/30/2024, 8:58:04 AM: ✔️   Successfully signed in to https://example.com/admin!
 ihole-sync  | 6/30/2024, 8:58:04 AM: ➡️   Uploading backup to https://example.com/admin...
 ihole-sync  | 6/30/2024, 8:58:04 AM: {"host":"https://example.com","path":"/admin","status":200,"responseBody":"Not authorized"}
pihole-sync  | 6/30/2024, 8:58:04 AM: ⚠ Error: Failed to upload backup to "https://example.com/admin".
pihole-sync  | 6/30/2024, 8:58:04 AM: ⚠ Failure: 0/3 hosts synced.
pihole-sync  | 6/30/2024, 8:58:04 AM: Waiting 1 minutes...
pihole-sync  | 6/30/2024, 8:59:04 AM: ➡️   Signing in to https://example.com/admin!
pihole-sync  | 6/30/2024, 8:59:04 AM: ➡️   Uploading backup to https://example.com/admin!
pihole-sync  | 6/30/2024, 8:59:04 AM: ➡️   Uploading backup to https://example.com","path":"/admin","status":200,"responseBody":"Not authorized"}
pihole-sync  | 6/30/2024, 8:59:04 AM: ⚠ Error: Failed to upload backup to "https://example.com/admin".
pihole-sync  | 6/30/2024, 8:59:04 AM: {"host":"https://example.com","path":"/admin","status":200,"responseBody":"Not authorized"}
pihole-sync  | 6/30/2024, 8:59:04 AM: ⚠ Error: Failed to upload backup to "https://example.com/admin".
pihole-sync  | 6/30/2024, 8:59:05 AM: ✔️"  Successfully signed in to https://example.com/admin!
pihole-sync  | 6/30/2024, 8:59:05 AM: ➡️"  Uploading backup to https://example.com","path":"/admin","status":200,"responseBody":"Not authorized"}
pihole-sync  | 6/30/2024, 8:59:05 AM: ⚠ Error: Failed to upload backup to "https://example.com/admin".
pihole-sync  | 6/30/2024, 8:59:05 AM: ⚠ Failure: 0/3 hosts synced.
pihole-sync  | 6/30/2024, 8:59:05 AM: Waiting 1 minutes...
```


I tracked the upload failure, and it is related to the `persistentlogin` cookie being sent with the upload request:

![image](https://github.com/mattwebbio/orbital-sync/assets/11147206/8fc5df5a-3052-4de0-8e75-347b3e7b18e6)

When I try the same request without this cookie, the upload works:

![image](https://github.com/mattwebbio/orbital-sync/assets/11147206/c3b84ca4-65f2-4fc7-b625-e4bd1d8c28bd)


This cookie comes from the `&persistentlogin=off` part of the request sent during the login (https://github.com/mattwebbio/orbital-sync/blob/master/src/client/v5/index.ts#L42)

When this part is appended to the request, the `persistentlogin` cookie is received (and is then sent during the backup upload request):

![image](https://github.com/mattwebbio/orbital-sync/assets/11147206/a253dfd8-5957-467e-a714-da6cb1e0a8e6)


When i remove this part, the cookie is not set and the upload works:
![image](https://github.com/mattwebbio/orbital-sync/assets/11147206/65d40e78-f106-4421-bd25-971f0efba546)




