### PR TITLE
#190 - work on factory pattern ready for v6 codebase

### DIFF
--- a/src/client/factory.ts
+++ b/src/client/factory.ts
@@ -6,34 +6,34 @@ import { Client } from './index.js';
 import { ClientV5 } from './v5/index.js';
 
 export class ClientFacory {
-    static createSource(
-        version: Version,
-        config: ConfigInterface,
-        log: Log,
-    ): Promise<Client> {
-        switch (version) {
-            case Version.v5: {
-                const host = new HostV5(config.sync.primaryHost);
-                return ClientV5.create({host, config, log});
-            }
-            default:
-                throw Error();
-        }
+  static createSource(
+    version: Version,
+    config: ConfigInterface,
+    log: Log
+  ): Promise<Client> {
+    switch (version) {
+      case Version.v5: {
+        const host = new HostV5(config.sync.primaryHost);
+        return ClientV5.create({ host, config, log });
+      }
+      default:
+        throw Error();
     }
+  }
 
-    public static createDestinations(
-        version: Version,
-        config: ConfigInterface,
-        log: Log,
-    ): Promise<Client>[] {
-        switch (version) {
-            case Version.v5:
-                return config.sync.secondaryHosts.map(hostConfig => {
-                    const host = new HostV5(hostConfig);
-                    return ClientV5.create({ host, config, log });
-                });
-            default:
-                throw Error();
-        }
+  public static createDestinations(
+    version: Version,
+    config: ConfigInterface,
+    log: Log
+  ): Promise<Client>[] {
+    switch (version) {
+      case Version.v5:
+        return config.sync.secondaryHosts.map((hostConfig) => {
+          const host = new HostV5(hostConfig);
+          return ClientV5.create({ host, config, log });
+        });
+      default:
+        throw Error();
     }
+  }
 }

--- a/src/client/factory.ts
+++ b/src/client/factory.ts
@@ -1,0 +1,39 @@
+import { ConfigInterface } from '../config/index.js';
+import { Version } from '../config/version.js';
+import { HostV5 } from '../host/v5/index.js';
+import { Log } from '../log.js';
+import { Client } from './index.js';
+import { ClientV5 } from './v5/index.js';
+
+export class ClientFacory {
+    static createSource(
+        version: Version,
+        config: ConfigInterface,
+        log: Log,
+    ): Promise<Client> {
+        switch (version) {
+            case Version.v5: {
+                const host = new HostV5(config.sync.primaryHost);
+                return ClientV5.create({host, config, log});
+            }
+            default:
+                throw Error();
+        }
+    }
+
+    public static createDestinations(
+        version: Version,
+        config: ConfigInterface,
+        log: Log,
+    ): Promise<Client>[] {
+        switch (version) {
+            case Version.v5:
+                return config.sync.secondaryHosts.map(hostConfig => {
+                    const host = new HostV5(hostConfig);
+                    return ClientV5.create({ host, config, log });
+                });
+            default:
+                throw Error();
+        }
+    }
+}

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,0 +1,18 @@
+import { ConfigInterface } from "../config/index.js";
+import { Host } from "../host/index.js";
+import { Log } from "../log.js";
+import { NodeFetchCookie } from "./nodefetchcookie.js";
+
+export abstract class Client {
+  protected constructor(
+    protected fetch: NodeFetchCookie,
+    protected host: Host,
+    protected token: string,
+    protected config: ConfigInterface,
+    protected log: Log
+  ) {}
+
+  public abstract makeBackup(): Promise<Blob>;
+  public abstract restoreBackup(backup: Blob): Promise<true | never>;
+  public getId = (): string => this.host.getId()
+}

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,7 +1,7 @@
-import { ConfigInterface } from "../config/index.js";
-import { Host } from "../host/index.js";
-import { Log } from "../log.js";
-import { NodeFetchCookie } from "./nodefetchcookie.js";
+import { ConfigInterface } from '../config/index.js';
+import { Host } from '../host/index.js';
+import { Log } from '../log.js';
+import { NodeFetchCookie } from './nodefetchcookie.js';
 
 export abstract class Client {
   protected constructor(
@@ -14,5 +14,5 @@ export abstract class Client {
 
   public abstract makeBackup(): Promise<Blob>;
   public abstract restoreBackup(backup: Blob): Promise<true | never>;
-  public getId = (): string => this.host.getId()
+  public getId = (): string => this.host.getId();
 }

--- a/src/client/nodefetchcookie.ts
+++ b/src/client/nodefetchcookie.ts
@@ -1,4 +1,6 @@
-import fetchCookie from "fetch-cookie";
-import { RequestInfo, RequestInit, Response } from "node-fetch";
+import fetchCookie from 'fetch-cookie';
+import { RequestInfo, RequestInit, Response } from 'node-fetch';
 
-export type NodeFetchCookie = ReturnType<typeof fetchCookie<RequestInfo, RequestInit, Response>>;
+export type NodeFetchCookie = ReturnType<
+  typeof fetchCookie<RequestInfo, RequestInit, Response>
+>;

--- a/src/client/nodefetchcookie.ts
+++ b/src/client/nodefetchcookie.ts
@@ -1,0 +1,4 @@
+import fetchCookie from "fetch-cookie";
+import { RequestInfo, RequestInit, Response } from "node-fetch";
+
+export type NodeFetchCookie = ReturnType<typeof fetchCookie<RequestInfo, RequestInit, Response>>;

--- a/src/client/v5/index.ts
+++ b/src/client/v5/index.ts
@@ -136,6 +136,10 @@ export class ClientV5 extends Client {
     this.log.info(chalk.green(`✔️ Backup uploaded to ${this.host.fullUrl}!`));
     this.log.verbose(`Result:\n${chalk.blue(uploadText)}`);
 
+    if (this.config.sync.updateGravity) {
+      await this.updateGravity();
+    }
+
     return true;
   }
 

--- a/src/client/v5/index.ts
+++ b/src/client/v5/index.ts
@@ -1,9 +1,6 @@
 import chalk from 'chalk';
 import fetchCookie from 'fetch-cookie';
-import nodeFetch, {
-  Blob,
-  FormData,
-} from 'node-fetch';
+import nodeFetch, { Blob, FormData } from 'node-fetch';
 import { parse } from 'node-html-parser';
 import { Log } from '../../log.js';
 import { ErrorNotification } from '../../notify/index.js';
@@ -12,7 +9,11 @@ import { HostV5 } from '../../host/v5/index.js';
 import { Client } from '../index.js';
 
 export class ClientV5 extends Client {
-  public static async create({ host, config, log }: {
+  public static async create({
+    host,
+    config,
+    log
+  }: {
     host: HostV5;
     config: ConfigInterfaceV5;
     log: Log;

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -4,7 +4,7 @@ import { Schemas } from './schema.js';
 import { Version } from './version.js';
 
 export type ConfigInterface = FromSchema<(typeof Schemas)[keyof typeof Schemas]>;
-export type ConfigInterfaceV5 = FromSchema<typeof Schemas[Version.v5]>;
+export type ConfigInterfaceV5 = FromSchema<(typeof Schemas)[Version.v5]>;
 
 export function Config(
   version: Version = Version.v5,

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,13 +1,15 @@
 import { parseSchema, RecursivePartial } from './parse.js';
 import { FromSchema } from 'json-schema-to-ts';
-import { Schema } from './schema.js';
+import { Schemas } from './schema.js';
+import { Version } from './version.js';
 
-export type ConfigInterface = FromSchema<typeof Schema>;
-export type SyncOptionsV5 = ConfigInterface['sync']['v5'];
+export type ConfigInterface = FromSchema<(typeof Schemas)[keyof typeof Schemas]>;
+export type ConfigInterfaceV5 = FromSchema<typeof Schemas[Version.v5]>;
 
 export function Config(
+  version: Version = Version.v5,
   overrides: RecursivePartial<ConfigInterface> = {}
 ): ConfigInterface {
   // @ts-expect-error - Type instantiation is excessively deep and possibly infinite
-  return parseSchema(Schema, { overrides });
+  return parseSchema(Schemas[version], { overrides });
 }

--- a/src/config/parse.ts
+++ b/src/config/parse.ts
@@ -8,7 +8,7 @@ import { camelToSnakeCase } from '../util/string-case.js';
 
 /*
   While the return type of this function should be accurate, the internal type checking
-  of the values being returned are not (particularly, there are a few `unknown`s and 
+  of the values being returned are not (particularly, there are a few `unknown`s and
   `any`s in here). TypeScript seems to be unable to properly infer the types of the values
   encased in the JSONSchema, and any attempts to correct this seem to cause the classic
   `type instantiation is excessively deep and possibly infinite`:

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,177 +1,37 @@
 import { asConst } from 'json-schema-to-ts';
+import { Version } from '../config/version.js';
 
-export const Schema = asConst({
+export const SchemaV5 = asConst({
   type: 'object',
   properties: {
-    primaryHost: {
-      type: 'object',
-      description: 'The primary Pi-hole that data will be copied from.',
-      properties: {
-        baseUrl: {
-          type: 'string',
-          envVar: 'PRIMARY_HOST_BASE_URL',
-          example: '`http://192.168.1.2` or `https://pihole.example.com`',
-          description:
-            'The base URL of your Pi-hole, including the scheme (HTTP or HTTPS) and port but not including a following slash.'
-        },
-        password: {
-          type: 'string',
-          envVar: 'PRIMARY_HOST_PASSWORD',
-          example: '`mypassword`',
-          description: 'The password used to log in to the admin interface.'
-        },
-        path: {
-          type: 'string',
-          envVar: 'PRIMARY_HOST_PATH',
-          example: '`/` or `/apps/pi-hole`',
-          description:
-            'The path to be appended to your base URL. The default Pi-hole path is `/admin`, which is added automatically.'
-        }
-      },
-      required: ['baseUrl', 'password']
+    version: {
+      type: 'string',
+      default: 'v5',
+      envVar: 'VERSION',
+      enum: ['v5'],
     },
-    secondaryHosts: {
-      type: 'array',
-      items: {
-        type: 'object',
-        description: 'Secondary Pi-holes that data will be copied to.',
-        properties: {
-          baseUrl: {
-            type: 'string',
-            envVar: 'SECONDARY_HOST_{{i}}_BASE_URL',
-            example: '`http://192.168.1.3` or `https://pihole2.example.com`',
-            description:
-              'The base URL of your secondary Pi-hole, including the scheme (HTTP or HTTPS) and port but not including a following slash.'
-          },
-          password: {
-            type: 'string',
-            envVar: 'SECONDARY_HOST_{{i}}_PASSWORD',
-            example: '`mypassword2`',
-            description: 'The password used to log in to the admin interface.'
-          },
-          path: {
-            type: 'string',
-            envVar: 'SECONDARY_HOST_{{i}}_PATH',
-            example: '`/` or `/apps/pi-hole`',
-            description:
-              'The path to be appended to your secondary base URL. The default Pi-hole path is `/admin`, which is added automatically.'
-          }
-        },
-        required: ['baseUrl', 'password']
-      },
-      minItems: 1
+    verbose: {
+      type: 'boolean',
+      default: false,
+      envVar: 'VERBOSE',
+      example: '`true`/`false`',
+      description: 'Increases the verbosity of log output. Useful for debugging.'
     },
-    sync: {
-      type: 'object',
+    runOnce: {
+      type: 'boolean',
+      default: false,
+      envVar: 'RUN_ONCE',
+      example: '`true`/`false`',
       description:
-        'What data to copy from the primary Pi-hole to the secondary Pi-holes.',
-      properties: {
-        v5: {
-          type: 'object',
-          description: 'Sync options for Pi-hole v5.x.',
-          properties: {
-            whitelist: {
-              type: 'boolean',
-              default: true,
-              envVar: 'SYNC_WHITELIST',
-              example: '`true`/`false`',
-              description: 'Copies the whitelist'
-            },
-            regexWhitelist: {
-              type: 'boolean',
-              default: true,
-              envVar: 'SYNC_REGEX_WHITELIST',
-              example: '`true`/`false`',
-              description: 'Copies the regex whitelist'
-            },
-            blacklist: {
-              type: 'boolean',
-              default: true,
-              envVar: 'SYNC_BLACKLIST',
-              example: '`true`/`false`',
-              description: 'Copies the blacklist'
-            },
-            regexList: {
-              type: 'boolean',
-              default: true,
-              envVar: 'SYNC_REGEXLIST',
-              example: '`true`/`false`',
-              description: 'Copies the regex blacklist'
-            },
-            adList: {
-              type: 'boolean',
-              default: true,
-              envVar: 'SYNC_ADLIST',
-              example: '`true`/`false`',
-              description: 'Copies adlists'
-            },
-            client: {
-              type: 'boolean',
-              default: true,
-              envVar: 'SYNC_CLIENT',
-              example: '`true`/`false`',
-              description: 'Copies clients'
-            },
-            group: {
-              type: 'boolean',
-              default: true,
-              envVar: 'SYNC_GROUP',
-              example: '`true`/`false`',
-              description: 'Copies groups'
-            },
-            auditLog: {
-              type: 'boolean',
-              default: false,
-              envVar: 'SYNC_AUDITLOG',
-              example: '`true`/`false`',
-              description: 'Copies the audit log'
-            },
-            staticDhcpLeases: {
-              type: 'boolean',
-              default: false,
-              envVar: 'SYNC_STATICDHCPLEASES',
-              example: '`true`/`false`',
-              description: 'Copies static DHCP leases'
-            },
-            localDnsRecords: {
-              type: 'boolean',
-              default: true,
-              envVar: 'SYNC_LOCALDNSRECORDS',
-              example: '`true`/`false`',
-              description: 'Copies local DNS records'
-            },
-            localCnameRecords: {
-              type: 'boolean',
-              default: true,
-              envVar: 'SYNC_LOCALCNAMERECORDS',
-              example: '`true`/`false`',
-              description: 'Copies local CNAME records'
-            },
-            flushTables: {
-              type: 'boolean',
-              default: true,
-              envVar: 'SYNC_FLUSHTABLES',
-              example: '`true`/`false`',
-              description: 'Clears existing data on the secondary (copy target) Pi-hole'
-            }
-          },
-          required: [
-            'whitelist',
-            'regexWhitelist',
-            'blacklist',
-            'regexList',
-            'adList',
-            'client',
-            'group',
-            'auditLog',
-            'staticDhcpLeases',
-            'localDnsRecords',
-            'localCnameRecords',
-            'flushTables'
-          ]
-        }
-      },
-      required: ['v5']
+        'By default, Orbital Sync runs indefinitely until stopped. Setting this to `true` forces it to exit immediately after the first sync.'
+    },
+    intervalMinutes: {
+      type: 'number',
+      default: 60,
+      envVar: 'INTERVAL_MINUTES',
+      example: 'Any non-zero positive integer, for example `5`, `30`, or `1440`',
+      description:
+        'How long to wait between synchronizations. Defaults to five minutes. Remember that the DNS server on your secondary servers restarts every time a sync is performed.'
     },
     notify: {
       type: 'object',
@@ -272,46 +132,200 @@ export const Schema = asConst({
         }
       }
     },
-    updateGravity: {
-      type: 'boolean',
-      default: true,
-      envVar: 'UPDATE_GRAVITY',
-      example: '`true`/`false`',
-      description:
-        'Triggers a gravity update after a backup has been uploaded to a secondary Pi-hole. This updates adlists and restarts gravity.'
+    sync: {
+      type: 'object',
+      description: 'The primary Pi-hole that data will be copied from.',
+      properties: {
+        primaryHost: {
+          type: 'object',
+          description: 'The primary Pi-hole that data will be copied from.',
+          properties: {
+            baseUrl: {
+              type: 'string',
+              envVar: 'PRIMARY_HOST_BASE_URL',
+              example: '`http://192.168.1.2` or `https://pihole.example.com`',
+              description:
+                'The base URL of your Pi-hole, including the scheme (HTTP or HTTPS) and port but not including a following slash.'
+            },
+            password: {
+              type: 'string',
+              envVar: 'PRIMARY_HOST_PASSWORD',
+              example: '`mypassword`',
+              description: 'The password used to log in to the admin interface.'
+            },
+            path: {
+              type: 'string',
+              envVar: 'PRIMARY_HOST_PATH',
+              example: '`/` or `/apps/pi-hole`',
+              description:
+                'The path to be appended to your base URL. The default Pi-hole path is `/admin`, which is added automatically.'
+            }
+          },
+          required: ['baseUrl', 'password']
+        },
+        secondaryHosts: {
+          type: 'array',
+          items: {
+            type: 'object',
+            description: 'Secondary Pi-holes that data will be copied to.',
+            properties: {
+              baseUrl: {
+                type: 'string',
+                envVar: 'SECONDARY_HOST_{{i}}_BASE_URL',
+                example: '`http://192.168.1.3` or `https://pihole2.example.com`',
+                description:
+                  'The base URL of your secondary Pi-hole, including the scheme (HTTP or HTTPS) and port but not including a following slash.'
+              },
+              password: {
+                type: 'string',
+                envVar: 'SECONDARY_HOST_{{i}}_PASSWORD',
+                example: '`mypassword2`',
+                description: 'The password used to log in to the admin interface.'
+              },
+              path: {
+                type: 'string',
+                envVar: 'SECONDARY_HOST_{{i}}_PATH',
+                example: '`/` or `/apps/pi-hole`',
+                description:
+                  'The path to be appended to your secondary base URL. The default Pi-hole path is `/admin`, which is added automatically.'
+              }
+            },
+            required: ['baseUrl', 'password']
+          },
+          minItems: 1
+        },
+        sync: {
+          type: 'object',
+          description:
+            'What data to copy from the primary Pi-hole to the secondary Pi-holes.',
+          properties: {
+            whitelist: {
+              type: 'boolean',
+              default: true,
+              envVar: 'SYNC_WHITELIST',
+              example: '`true`/`false`',
+              description: 'Copies the whitelist'
+            },
+            regexWhitelist: {
+              type: 'boolean',
+              default: true,
+              envVar: 'SYNC_REGEX_WHITELIST',
+              example: '`true`/`false`',
+              description: 'Copies the regex whitelist'
+            },
+            blacklist: {
+              type: 'boolean',
+              default: true,
+              envVar: 'SYNC_BLACKLIST',
+              example: '`true`/`false`',
+              description: 'Copies the blacklist'
+            },
+            regexList: {
+              type: 'boolean',
+              default: true,
+              envVar: 'SYNC_REGEXLIST',
+              example: '`true`/`false`',
+              description: 'Copies the regex blacklist'
+            },
+            adList: {
+              type: 'boolean',
+              default: true,
+              envVar: 'SYNC_ADLIST',
+              example: '`true`/`false`',
+              description: 'Copies adlists'
+            },
+            client: {
+              type: 'boolean',
+              default: true,
+              envVar: 'SYNC_CLIENT',
+              example: '`true`/`false`',
+              description: 'Copies clients'
+            },
+            group: {
+              type: 'boolean',
+              default: true,
+              envVar: 'SYNC_GROUP',
+              example: '`true`/`false`',
+              description: 'Copies groups'
+            },
+            auditLog: {
+              type: 'boolean',
+              default: false,
+              envVar: 'SYNC_AUDITLOG',
+              example: '`true`/`false`',
+              description: 'Copies the audit log'
+            },
+            staticDhcpLeases: {
+              type: 'boolean',
+              default: false,
+              envVar: 'SYNC_STATICDHCPLEASES',
+              example: '`true`/`false`',
+              description: 'Copies static DHCP leases'
+            },
+            localDnsRecords: {
+              type: 'boolean',
+              default: true,
+              envVar: 'SYNC_LOCALDNSRECORDS',
+              example: '`true`/`false`',
+              description: 'Copies local DNS records'
+            },
+            localCnameRecords: {
+              type: 'boolean',
+              default: true,
+              envVar: 'SYNC_LOCALCNAMERECORDS',
+              example: '`true`/`false`',
+              description: 'Copies local CNAME records'
+            },
+            flushTables: {
+              type: 'boolean',
+              default: true,
+              envVar: 'SYNC_FLUSHTABLES',
+              example: '`true`/`false`',
+              description: 'Clears existing data on the secondary (copy target) Pi-hole'
+            }
+          },
+          required: [
+            'whitelist',
+            'regexWhitelist',
+            'blacklist',
+            'regexList',
+            'adList',
+            'client',
+            'group',
+            'auditLog',
+            'staticDhcpLeases',
+            'localDnsRecords',
+            'localCnameRecords',
+            'flushTables'
+          ]
+        },
+        updateGravity: {
+          type: 'boolean',
+          default: true,
+          envVar: 'UPDATE_GRAVITY',
+          example: '`true`/`false`',
+          description:
+            'Triggers a gravity update after a backup has been uploaded to a secondary Pi-hole. This updates adlists and restarts gravity.'
+        },
+      },
+      required: [
+        'primaryHost',
+        'secondaryHosts',
+        'sync',
+        'updateGravity',
+      ]
     },
-    verbose: {
-      type: 'boolean',
-      default: false,
-      envVar: 'VERBOSE',
-      example: '`true`/`false`',
-      description: 'Increases the verbosity of log output. Useful for debugging.'
-    },
-    runOnce: {
-      type: 'boolean',
-      default: false,
-      envVar: 'RUN_ONCE',
-      example: '`true`/`false`',
-      description:
-        'By default, Orbital Sync runs indefinitely until stopped. Setting this to `true` forces it to exit immediately after the first sync.'
-    },
-    intervalMinutes: {
-      type: 'number',
-      default: 60,
-      envVar: 'INTERVAL_MINUTES',
-      example: 'Any non-zero positive integer, for example `5`, `30`, or `1440`',
-      description:
-        'How long to wait between synchronizations. Defaults to five minutes. Remember that the DNS server on your secondary servers restarts every time a sync is performed.'
-    }
   },
   required: [
-    'primaryHost',
-    'secondaryHosts',
-    'sync',
-    'notify',
-    'updateGravity',
+    'version',
     'verbose',
     'runOnce',
-    'intervalMinutes'
-  ]
+    'intervalMinutes',
+    'notify',
+    'sync',
+  ],
 });
+
+export const Schemas: Record<Version, typeof SchemaV5 | typeof SchemaV5> = {
+  [Version.v5]: SchemaV5,
+};

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -194,110 +194,89 @@ export const SchemaV5 = asConst({
           },
           minItems: 1
         },
-        sync: {
-          type: 'object',
-          description:
-            'What data to copy from the primary Pi-hole to the secondary Pi-holes.',
-          properties: {
-            whitelist: {
-              type: 'boolean',
-              default: true,
-              envVar: 'SYNC_WHITELIST',
-              example: '`true`/`false`',
-              description: 'Copies the whitelist'
-            },
-            regexWhitelist: {
-              type: 'boolean',
-              default: true,
-              envVar: 'SYNC_REGEX_WHITELIST',
-              example: '`true`/`false`',
-              description: 'Copies the regex whitelist'
-            },
-            blacklist: {
-              type: 'boolean',
-              default: true,
-              envVar: 'SYNC_BLACKLIST',
-              example: '`true`/`false`',
-              description: 'Copies the blacklist'
-            },
-            regexList: {
-              type: 'boolean',
-              default: true,
-              envVar: 'SYNC_REGEXLIST',
-              example: '`true`/`false`',
-              description: 'Copies the regex blacklist'
-            },
-            adList: {
-              type: 'boolean',
-              default: true,
-              envVar: 'SYNC_ADLIST',
-              example: '`true`/`false`',
-              description: 'Copies adlists'
-            },
-            client: {
-              type: 'boolean',
-              default: true,
-              envVar: 'SYNC_CLIENT',
-              example: '`true`/`false`',
-              description: 'Copies clients'
-            },
-            group: {
-              type: 'boolean',
-              default: true,
-              envVar: 'SYNC_GROUP',
-              example: '`true`/`false`',
-              description: 'Copies groups'
-            },
-            auditLog: {
-              type: 'boolean',
-              default: false,
-              envVar: 'SYNC_AUDITLOG',
-              example: '`true`/`false`',
-              description: 'Copies the audit log'
-            },
-            staticDhcpLeases: {
-              type: 'boolean',
-              default: false,
-              envVar: 'SYNC_STATICDHCPLEASES',
-              example: '`true`/`false`',
-              description: 'Copies static DHCP leases'
-            },
-            localDnsRecords: {
-              type: 'boolean',
-              default: true,
-              envVar: 'SYNC_LOCALDNSRECORDS',
-              example: '`true`/`false`',
-              description: 'Copies local DNS records'
-            },
-            localCnameRecords: {
-              type: 'boolean',
-              default: true,
-              envVar: 'SYNC_LOCALCNAMERECORDS',
-              example: '`true`/`false`',
-              description: 'Copies local CNAME records'
-            },
-            flushTables: {
-              type: 'boolean',
-              default: true,
-              envVar: 'SYNC_FLUSHTABLES',
-              example: '`true`/`false`',
-              description: 'Clears existing data on the secondary (copy target) Pi-hole'
-            }
-          },
-          required: [
-            'whitelist',
-            'regexWhitelist',
-            'blacklist',
-            'regexList',
-            'adList',
-            'client',
-            'group',
-            'auditLog',
-            'staticDhcpLeases',
-            'localDnsRecords',
-            'localCnameRecords',
-            'flushTables'
-          ]
+        whitelist: {
+          type: 'boolean',
+          default: true,
+          envVar: 'SYNC_WHITELIST',
+          example: '`true`/`false`',
+          description: 'Copies the whitelist'
+        },
+        regexWhitelist: {
+          type: 'boolean',
+          default: true,
+          envVar: 'SYNC_REGEX_WHITELIST',
+          example: '`true`/`false`',
+          description: 'Copies the regex whitelist'
+        },
+        blacklist: {
+          type: 'boolean',
+          default: true,
+          envVar: 'SYNC_BLACKLIST',
+          example: '`true`/`false`',
+          description: 'Copies the blacklist'
+        },
+        regexList: {
+          type: 'boolean',
+          default: true,
+          envVar: 'SYNC_REGEXLIST',
+          example: '`true`/`false`',
+          description: 'Copies the regex blacklist'
+        },
+        adList: {
+          type: 'boolean',
+          default: true,
+          envVar: 'SYNC_ADLIST',
+          example: '`true`/`false`',
+          description: 'Copies adlists'
+        },
+        client: {
+          type: 'boolean',
+          default: true,
+          envVar: 'SYNC_CLIENT',
+          example: '`true`/`false`',
+          description: 'Copies clients'
+        },
+        group: {
+          type: 'boolean',
+          default: true,
+          envVar: 'SYNC_GROUP',
+          example: '`true`/`false`',
+          description: 'Copies groups'
+        },
+        auditLog: {
+          type: 'boolean',
+          default: false,
+          envVar: 'SYNC_AUDITLOG',
+          example: '`true`/`false`',
+          description: 'Copies the audit log'
+        },
+        staticDhcpLeases: {
+          type: 'boolean',
+          default: false,
+          envVar: 'SYNC_STATICDHCPLEASES',
+          example: '`true`/`false`',
+          description: 'Copies static DHCP leases'
+        },
+        localDnsRecords: {
+          type: 'boolean',
+          default: true,
+          envVar: 'SYNC_LOCALDNSRECORDS',
+          example: '`true`/`false`',
+          description: 'Copies local DNS records'
+        },
+        localCnameRecords: {
+          type: 'boolean',
+          default: true,
+          envVar: 'SYNC_LOCALCNAMERECORDS',
+          example: '`true`/`false`',
+          description: 'Copies local CNAME records'
+        },
+        flushTables: {
+          type: 'boolean',
+          default: true,
+          envVar: 'SYNC_FLUSHTABLES',
+          example: '`true`/`false`',
+          description: 'Clears existing data on the secondary (copy target) Pi-hole'
         },
         updateGravity: {
           type: 'boolean',
@@ -308,7 +287,23 @@ export const SchemaV5 = asConst({
             'Triggers a gravity update after a backup has been uploaded to a secondary Pi-hole. This updates adlists and restarts gravity.'
         }
       },
-      required: ['primaryHost', 'secondaryHosts', 'sync', 'updateGravity']
+      required: [
+        'primaryHost',
+        'secondaryHosts',
+        'updateGravity',
+        'whitelist',
+        'regexWhitelist',
+        'blacklist',
+        'regexList',
+        'adList',
+        'client',
+        'group',
+        'auditLog',
+        'staticDhcpLeases',
+        'localDnsRecords',
+        'localCnameRecords',
+        'flushTables'
+      ]
     }
   },
   required: ['version', 'verbose', 'runOnce', 'intervalMinutes', 'notify', 'sync']

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -8,7 +8,7 @@ export const SchemaV5 = asConst({
       type: 'string',
       default: 'v5',
       envVar: 'VERSION',
-      enum: ['v5'],
+      enum: ['v5']
     },
     verbose: {
       type: 'boolean',
@@ -306,26 +306,14 @@ export const SchemaV5 = asConst({
           example: '`true`/`false`',
           description:
             'Triggers a gravity update after a backup has been uploaded to a secondary Pi-hole. This updates adlists and restarts gravity.'
-        },
+        }
       },
-      required: [
-        'primaryHost',
-        'secondaryHosts',
-        'sync',
-        'updateGravity',
-      ]
-    },
+      required: ['primaryHost', 'secondaryHosts', 'sync', 'updateGravity']
+    }
   },
-  required: [
-    'version',
-    'verbose',
-    'runOnce',
-    'intervalMinutes',
-    'notify',
-    'sync',
-  ],
+  required: ['version', 'verbose', 'runOnce', 'intervalMinutes', 'notify', 'sync']
 });
 
 export const Schemas: Record<Version, typeof SchemaV5 | typeof SchemaV5> = {
-  [Version.v5]: SchemaV5,
+  [Version.v5]: SchemaV5
 };

--- a/src/config/version.ts
+++ b/src/config/version.ts
@@ -1,3 +1,3 @@
 export enum Version {
-    v5,
+  v5
 }

--- a/src/config/version.ts
+++ b/src/config/version.ts
@@ -1,3 +1,3 @@
 export enum Version {
-  v5
+  v5 = 'v5',
 }

--- a/src/config/version.ts
+++ b/src/config/version.ts
@@ -1,3 +1,3 @@
 export enum Version {
-  v5 = 'v5',
+  v5 = 'v5'
 }

--- a/src/config/version.ts
+++ b/src/config/version.ts
@@ -1,0 +1,3 @@
+export enum Version {
+    v5,
+}

--- a/src/host/factory.ts
+++ b/src/host/factory.ts
@@ -1,0 +1,30 @@
+import { ConfigInterface } from '../config/index.js';
+import { Version } from '../config/version.js';
+import { Host } from './index.js';
+import { HostV5 } from './v5/index.js';
+
+export class HostFactory {
+    static createSource(
+        version: Version,
+        config: ConfigInterface,
+    ): Host {
+        switch (version) {
+            case Version.v5:
+                return new HostV5(config.sync.primaryHost);
+            default:
+                throw Error();
+        }
+    }
+
+    static createDestinations(
+        version: Version,
+        config: ConfigInterface,
+    ): Host[] {
+        switch (version) {
+            case Version.v5:
+                return config.sync.secondaryHosts.map(host => new HostV5(host));
+            default:
+                throw Error();
+        }
+    }
+}

--- a/src/host/factory.ts
+++ b/src/host/factory.ts
@@ -4,27 +4,21 @@ import { Host } from './index.js';
 import { HostV5 } from './v5/index.js';
 
 export class HostFactory {
-    static createSource(
-        version: Version,
-        config: ConfigInterface,
-    ): Host {
-        switch (version) {
-            case Version.v5:
-                return new HostV5(config.sync.primaryHost);
-            default:
-                throw Error();
-        }
+  static createSource(version: Version, config: ConfigInterface): Host {
+    switch (version) {
+      case Version.v5:
+        return new HostV5(config.sync.primaryHost);
+      default:
+        throw Error();
     }
+  }
 
-    static createDestinations(
-        version: Version,
-        config: ConfigInterface,
-    ): Host[] {
-        switch (version) {
-            case Version.v5:
-                return config.sync.secondaryHosts.map(host => new HostV5(host));
-            default:
-                throw Error();
-        }
+  static createDestinations(version: Version, config: ConfigInterface): Host[] {
+    switch (version) {
+      case Version.v5:
+        return config.sync.secondaryHosts.map((host) => new HostV5(host));
+      default:
+        throw Error();
     }
+  }
 }

--- a/src/host/index.ts
+++ b/src/host/index.ts
@@ -1,10 +1,8 @@
-export class Host {
+export abstract class Host {
   baseUrl: string;
   path: string;
   fullUrl: string;
   password: string;
-
-  private static pathExtractor = RegExp('^(http[s]?:+//[^/s]+)([/]?[^?#]+)?');
 
   constructor({
     baseUrl,
@@ -20,7 +18,8 @@ export class Host {
       path = '/' + path;
     }
 
-    const includedPath = Host.pathExtractor.exec(baseUrl);
+    const pathExtractor = RegExp('^(http[s]?:+//[^/s]+)([/]?[^?#]+)?');
+    const includedPath = pathExtractor.exec(baseUrl);
 
     if (includedPath && includedPath[1] && includedPath[2]) {
       baseUrl = includedPath[1];
@@ -35,5 +34,9 @@ export class Host {
 
   private trimTrailingSlash(url: string): string {
     return url.endsWith('/') ? url.slice(0, url.length - 1) : url;
+  }
+
+  public getId(): string {
+    return this.baseUrl;
   }
 }

--- a/src/host/v5/index.ts
+++ b/src/host/v5/index.ts
@@ -1,0 +1,4 @@
+import { Host } from '../index.js';
+
+export class HostV5 extends Host {
+}

--- a/src/host/v5/index.ts
+++ b/src/host/v5/index.ts
@@ -1,4 +1,3 @@
 import { Host } from '../index.js';
 
-export class HostV5 extends Host {
-}
+export class HostV5 extends Host {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,19 @@ import sleep from 'sleep-promise';
 import { Log } from './log.js';
 import { Sync } from './sync.js';
 import { Config } from './config/index.js';
+import { Version } from './config/version.js'
 
-const config = Config();
+// need to do this to know how to parse the config
+if (undefined === process.env.VERSION) {
+  throw new Error("VERSION is required")
+}
+const version: Version | undefined = process.env.VERSION as unknown as Version;
+if (undefined === version) {
+  throw new Error(`VERSION must be one of ${Object.values(Version)}`);
+}
+
+const config = Config(version);
+
 const log = new Log(config.verbose);
 
 do {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,11 +5,11 @@ import sleep from 'sleep-promise';
 import { Log } from './log.js';
 import { Sync } from './sync.js';
 import { Config } from './config/index.js';
-import { Version } from './config/version.js'
+import { Version } from './config/version.js';
 
 // need to do this to know how to parse the config
 if (undefined === process.env.VERSION) {
-  throw new Error("VERSION is required")
+  throw new Error('VERSION is required');
 }
 const version: Version | undefined = process.env.VERSION as unknown as Version;
 if (undefined === version) {

--- a/src/notify/factory.ts
+++ b/src/notify/factory.ts
@@ -4,11 +4,7 @@ import { NotifyV5 } from './v5/index.js';
 import { Version } from '../config/version.js';
 
 export class NotifyFactory {
-  static create(
-    version: Version,
-    config: ConfigInterface,
-    log: Log,
-  ) {
+  static create(version: Version, config: ConfigInterface, log: Log) {
     switch (version) {
       case Version.v5:
         return new NotifyV5(config, log);

--- a/src/notify/factory.ts
+++ b/src/notify/factory.ts
@@ -1,0 +1,19 @@
+import { Log } from '../log.js';
+import { ConfigInterface } from '../config/index.js';
+import { NotifyV5 } from './v5/index.js';
+import { Version } from '../config/version.js';
+
+export class NotifyFactory {
+  static create(
+    version: Version,
+    config: ConfigInterface,
+    log: Log,
+  ) {
+    switch (version) {
+      case Version.v5:
+        return new NotifyV5(config, log);
+      default:
+        throw Error();
+    }
+  }
+}

--- a/src/notify/index.ts
+++ b/src/notify/index.ts
@@ -2,25 +2,22 @@ import Honeybadger from '@honeybadger-io/js';
 import Sentry from '@sentry/node';
 import { FetchError } from 'node-fetch';
 import nodemailer from 'nodemailer';
-import { Log } from './log.js';
-import { ConfigInterface } from './config/index.js';
-import { Host } from './client/host.js';
+import { Log } from '../log.js';
+import { ConfigInterface } from '../config/index.js';
 
-export class Notify {
+export abstract class Notify {
   private errorQueue: NotificationInterface[] = [];
   private _honeybadger?: Honeybadger;
   private _sentry?: typeof Sentry;
   private _smtpClient?: nodemailer.Transporter;
-  private allHostUrls: string[];
+  protected allHostUrls: string[];
 
   constructor(
     private config: ConfigInterface,
     private log: Log = new Log(config.verbose)
   ) {
-    this.allHostUrls = [config.primaryHost, ...config.secondaryHosts].map(
-      (host) => new Host(host).fullUrl
-    );
-  }
+    this.allHostUrls = [];
+  };
 
   async ofThrow(error: unknown, queue = false): Promise<void> {
     if (error instanceof ErrorNotification) {

--- a/src/notify/index.ts
+++ b/src/notify/index.ts
@@ -17,7 +17,7 @@ export abstract class Notify {
     private log: Log = new Log(config.verbose)
   ) {
     this.allHostUrls = [];
-  };
+  }
 
   async ofThrow(error: unknown, queue = false): Promise<void> {
     if (error instanceof ErrorNotification) {

--- a/src/notify/v5/index.ts
+++ b/src/notify/v5/index.ts
@@ -1,14 +1,11 @@
-import { ConfigInterface } from "../../config/index.js";
-import { Log } from "../../log.js";
-import { Notify } from "../index.js";
-import { HostV5 } from "../../host/v5/index.js";
+import { ConfigInterface } from '../../config/index.js';
+import { Log } from '../../log.js';
+import { Notify } from '../index.js';
+import { HostV5 } from '../../host/v5/index.js';
 
 export class NotifyV5 extends Notify {
-  constructor(
-    config: ConfigInterface,
-    log: Log,
-  ) {
-    super(config, log)
+  constructor(config: ConfigInterface, log: Log) {
+    super(config, log);
 
     this.allHostUrls = [config.sync.primaryHost, ...config.sync.secondaryHosts].map(
       (host) => new HostV5(host).fullUrl

--- a/src/notify/v5/index.ts
+++ b/src/notify/v5/index.ts
@@ -1,0 +1,17 @@
+import { ConfigInterface } from "../../config/index.js";
+import { Log } from "../../log.js";
+import { Notify } from "../index.js";
+import { HostV5 } from "../../host/v5/index.js";
+
+export class NotifyV5 extends Notify {
+  constructor(
+    config: ConfigInterface,
+    log: Log,
+  ) {
+    super(config, log)
+
+    this.allHostUrls = [config.sync.primaryHost, ...config.sync.secondaryHosts].map(
+      (host) => new HostV5(host).fullUrl
+    );
+  }
+}

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1,55 +1,47 @@
-import { Host } from './client/host.js';
-import { ClientV5 } from './client/v5/index.js';
 import { ConfigInterface } from './config/index.js';
+import { Version } from './config/version.js';
 import { Log } from './log.js';
-import { Notify } from './notify.js';
+import { NotifyFactory } from './notify/factory.js';
+import { ClientFacory } from './client/factory.js';
+import chalk from 'chalk';
 
 export class Sync {
   static async perform(
     config: ConfigInterface,
-    { notify: _notify, log: _log }: { notify?: Notify; log?: Log } = {}
+    { log: _log }: { log?: Log } = {}
   ): Promise<void> {
-    const notify = _notify ?? new Notify(config);
+    const version: Version =config.version as unknown as Version;
     const log = _log ?? new Log(config.verbose);
+    const notify = NotifyFactory.create(version, config, log);
 
     try {
-      const primaryHost = await ClientV5.create({
-        host: new Host(config.primaryHost),
-        options: config.sync.v5,
-        log
-      });
-      const backup = await primaryHost.downloadBackup();
+      const primaryClient = await ClientFacory.createSource(version, config, log);
+      const backup = await primaryClient.makeBackup();
 
-      const secondaryHostCount = config.secondaryHosts?.length ?? 0;
-      const successfulRestoreCount = (
-        await Promise.all(
-          config.secondaryHosts.map((host) =>
-            ClientV5.create({ host: new Host(host), options: config.sync.v5, log })
-              .then(async (client) => {
-                let success = await client.uploadBackup(backup);
+      const restores = await Promise.all(
+        ClientFacory.createDestinations(version, config, log).map(async client => {
+          log.info(chalk.dim(`Restoring to client ${(await client).getId()}`));
+          return client
+            .then(async (client) => await client.restoreBackup(backup))
+            .catch((error) => notify.ofThrow(error, true));
+        })
+      );
 
-                if (success && config.updateGravity)
-                  success = await client.updateGravity();
+      const secondaryClientCount = restores.length;
+      const successfulRestoreCount = restores.filter(Boolean).length;
 
-                return success;
-              })
-              .catch((error) => notify.ofThrow(error, true))
-          )
-        )
-      ).filter(Boolean).length;
-
-      if (secondaryHostCount === successfulRestoreCount) {
+      if (secondaryClientCount === successfulRestoreCount) {
         await notify.ofSuccess({
-          message: `${successfulRestoreCount}/${secondaryHostCount} hosts synced.`
+          message: `${successfulRestoreCount}/${secondaryClientCount} hosts synced.`
         });
       } else if (successfulRestoreCount > 0) {
         await notify.ofFailure({
           sendNotification: config.notify.onSuccess || config.notify.onFailure,
-          message: `${successfulRestoreCount}/${secondaryHostCount} hosts synced.`
+          message: `${successfulRestoreCount}/${secondaryClientCount} hosts synced.`
         });
       } else {
         await notify.ofFailure({
-          message: `${successfulRestoreCount}/${secondaryHostCount} hosts synced.`
+          message: `${successfulRestoreCount}/${secondaryClientCount} hosts synced.`
         });
       }
     } catch (e: unknown) {

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -10,7 +10,7 @@ export class Sync {
     config: ConfigInterface,
     { log: _log }: { log?: Log } = {}
   ): Promise<void> {
-    const version: Version =config.version as unknown as Version;
+    const version: Version = config.version as unknown as Version;
     const log = _log ?? new Log(config.verbose);
     const notify = NotifyFactory.create(version, config, log);
 
@@ -19,7 +19,7 @@ export class Sync {
       const backup = await primaryClient.makeBackup();
 
       const restores = await Promise.all(
-        ClientFacory.createDestinations(version, config, log).map(async client => {
+        ClientFacory.createDestinations(version, config, log).map(async (client) => {
           log.info(chalk.dim(`Restoring to client ${(await client).getId()}`));
           return client
             .then(async (client) => await client.restoreBackup(backup))

--- a/test/unit/client/host.test.ts
+++ b/test/unit/client/host.test.ts
@@ -1,4 +1,3 @@
-import { Host } from '../../../src/host';
 import { HostV5 } from '../../../src/host/v5';
 
 describe('Client', () => {

--- a/test/unit/client/host.test.ts
+++ b/test/unit/client/host.test.ts
@@ -1,9 +1,10 @@
-import { Host } from '../../../src/client/host';
+import { Host } from '../../../src/host';
+import { HostV5 } from '../../../src/host/v5';
 
 describe('Client', () => {
   describe('Host', () => {
     test('should prepend / to path if not present', () => {
-      const host = new Host({
+      const host = new HostV5({
         baseUrl: 'http://10.0.0.3',
         path: 'foobar',
         password: 'mock'
@@ -14,7 +15,7 @@ describe('Client', () => {
     });
 
     test('should remove trailing slash if present', () => {
-      const host = new Host({
+      const host = new HostV5({
         baseUrl: 'http://10.0.0.3',
         path: '/foobar/',
         password: 'mock'
@@ -25,7 +26,7 @@ describe('Client', () => {
     });
 
     test('separates path and baseUrl if baseUrl has path', () => {
-      const host = new Host({ baseUrl: 'http://10.0.0.3/foobar', password: 'mock' });
+      const host = new HostV5({ baseUrl: 'http://10.0.0.3/foobar', password: 'mock' });
 
       expect(host.path).toBe('/foobar/admin');
       expect(host.fullUrl).toBe('http://10.0.0.3/foobar/admin');

--- a/test/unit/client/v5/index.test.ts
+++ b/test/unit/client/v5/index.test.ts
@@ -46,9 +46,7 @@ describe('Client', () => {
         const initialRequest = nock(host.fullUrl).get('/index.php?login').reply(200);
         const loginRequest = nock(host.fullUrl).post('/index.php?login').reply(500);
 
-        const expectError = expect(
-          ClientV5.create({ host, config, log })
-        ).rejects;
+        const expectError = expect(ClientV5.create({ host, config, log })).rejects;
 
         await expectError.toBeInstanceOf(ErrorNotification);
         await expectError.toMatchObject({
@@ -69,9 +67,7 @@ describe('Client', () => {
         const initialRequest = nock(host.fullUrl).get('/index.php?login').reply(200);
         const loginRequest = nock(host.fullUrl).post('/index.php?login').reply(200);
 
-        const expectError = expect(
-          ClientV5.create({ host, config, log })
-        ).rejects;
+        const expectError = expect(ClientV5.create({ host, config, log })).rejects;
 
         await expectError.toBeInstanceOf(ErrorNotification);
         await expectError.toMatchObject({
@@ -93,9 +89,7 @@ describe('Client', () => {
           .post('/index.php?login')
           .reply(200, '<html><body><div id="token">abcdef</div></body></html>');
 
-        const expectError = expect(
-          ClientV5.create({ host, config, log })
-        ).rejects;
+        const expectError = expect(ClientV5.create({ host, config, log })).rejects;
 
         await expectError.toBeInstanceOf(ErrorNotification);
         await expectError.toMatchObject({
@@ -120,9 +114,9 @@ describe('Client', () => {
             '<html><body><div id="token">abcdefgijklmnopqrstuvwxyzabcdefgijklmnopqrst</div></body></html>'
           );
 
-        await expect(
-          ClientV5.create({ host, config, log })
-        ).resolves.toBeInstanceOf(ClientV5);
+        await expect(ClientV5.create({ host, config, log })).resolves.toBeInstanceOf(
+          ClientV5
+        );
 
         initialRequest.done();
         loginRequest.done();

--- a/test/unit/config/index.test.ts
+++ b/test/unit/config/index.test.ts
@@ -25,13 +25,13 @@ describe('Config', () => {
         primaryHost: {
           baseUrl: 'http://localhost:3000',
           password: 'password',
-          path: undefined,
+          path: undefined
         },
         secondaryHosts: [
           {
             baseUrl: 'http://localhost:3001',
             password: 'password',
-            path: undefined,
+            path: undefined
           }
         ],
         adList: true,
@@ -46,7 +46,7 @@ describe('Config', () => {
         regexWhitelist: true,
         staticDhcpLeases: false,
         whitelist: true,
-        updateGravity: true,
+        updateGravity: true
       },
       notify: {
         exceptions: {
@@ -93,13 +93,13 @@ describe('Config', () => {
         primaryHost: {
           baseUrl: 'http://localhost:3000',
           password: 'password_from_file_1',
-          path: undefined,
+          path: undefined
         },
         secondaryHosts: [
           {
             baseUrl: 'http://localhost:3001',
             password: 'password_from_file_2',
-            path: undefined,
+            path: undefined
           }
         ],
         adList: true,
@@ -114,7 +114,7 @@ describe('Config', () => {
         regexWhitelist: true,
         staticDhcpLeases: false,
         whitelist: true,
-        updateGravity: true,
+        updateGravity: true
       },
       notify: {
         exceptions: {

--- a/test/unit/config/index.test.ts
+++ b/test/unit/config/index.test.ts
@@ -1,6 +1,7 @@
 import { writeFile } from 'node:fs/promises';
 import { temporaryFile } from 'tempy';
 import { Config } from '../../../src/config/index';
+import { Version } from '../../../src/config/version';
 
 describe('Config', () => {
   const initialEnv = Object.assign({}, process.env);
@@ -10,39 +11,42 @@ describe('Config', () => {
   });
 
   it('should generate configuration', () => {
+    process.env['VERSION'] = 'v5';
     process.env['PRIMARY_HOST_BASE_URL'] = 'http://localhost:3000';
     process.env['PRIMARY_HOST_PASSWORD'] = 'password';
 
-    process.env['SECONDARY_HOSTS_1_BASE_URL'] = 'http://localhost:3001';
-    process.env['SECONDARY_HOSTS_1_PASSWORD'] = 'password';
+    process.env['SECONDARY_HOST_1_BASE_URL'] = 'http://localhost:3001';
+    process.env['SECONDARY_HOST_1_PASSWORD'] = 'password';
 
     const config = Config();
     expect(config).toEqual({
-      primaryHost: {
-        baseUrl: 'http://localhost:3000',
-        password: 'password'
-      },
-      secondaryHosts: [
-        {
-          baseUrl: 'http://localhost:3001',
-          password: 'password'
-        }
-      ],
+      version: Version.v5.valueOf(),
       sync: {
-        v5: {
-          adList: true,
-          auditLog: false,
-          blacklist: true,
-          client: true,
-          flushTables: true,
-          group: true,
-          localCnameRecords: true,
-          localDnsRecords: true,
-          regexList: true,
-          regexWhitelist: true,
-          staticDhcpLeases: false,
-          whitelist: true
-        }
+        primaryHost: {
+          baseUrl: 'http://localhost:3000',
+          password: 'password',
+          path: undefined,
+        },
+        secondaryHosts: [
+          {
+            baseUrl: 'http://localhost:3001',
+            password: 'password',
+            path: undefined,
+          }
+        ],
+        adList: true,
+        auditLog: false,
+        blacklist: true,
+        client: true,
+        flushTables: true,
+        group: true,
+        localCnameRecords: true,
+        localDnsRecords: true,
+        regexList: true,
+        regexWhitelist: true,
+        staticDhcpLeases: false,
+        whitelist: true,
+        updateGravity: true,
       },
       notify: {
         exceptions: {
@@ -64,7 +68,6 @@ describe('Config', () => {
       },
       intervalMinutes: 60,
       runOnce: false,
-      updateGravity: true,
       verbose: false
     });
   });
@@ -75,39 +78,43 @@ describe('Config', () => {
     const passwordFile2 = temporaryFile();
     await writeFile(passwordFile2, 'password_from_file_2\n', 'utf-8');
 
+    process.env['VERSION'] = 'v5';
     process.env['PRIMARY_HOST_BASE_URL'] = 'http://localhost:3000';
-    process.env['PRIMARY_HOST_PASSWORD_FILE'] = passwordFile1;
+    process.env['PRIMARY_HOST_BASE_URL'] = 'http://localhost:3000';
+    process.env['SYNC_PRIMARY_HOST_PASSWORD_FILE'] = passwordFile1;
 
-    process.env['SECONDARY_HOSTS_1_BASE_URL'] = 'http://localhost:3001';
-    process.env['SECONDARY_HOSTS_1_PASSWORD_FILE'] = passwordFile2;
+    process.env['SECONDARY_HOST_1_BASE_URL'] = 'http://localhost:3001';
+    process.env['SYNC_SECONDARY_HOSTS_1_PASSWORD_FILE'] = passwordFile2;
 
     const config = Config();
     expect(config).toEqual({
-      primaryHost: {
-        baseUrl: 'http://localhost:3000',
-        password: 'password_from_file_1'
-      },
-      secondaryHosts: [
-        {
-          baseUrl: 'http://localhost:3001',
-          password: 'password_from_file_2'
-        }
-      ],
+      version: Version.v5.valueOf(),
       sync: {
-        v5: {
-          adList: true,
-          auditLog: false,
-          blacklist: true,
-          client: true,
-          flushTables: true,
-          group: true,
-          localCnameRecords: true,
-          localDnsRecords: true,
-          regexList: true,
-          regexWhitelist: true,
-          staticDhcpLeases: false,
-          whitelist: true
-        }
+        primaryHost: {
+          baseUrl: 'http://localhost:3000',
+          password: 'password_from_file_1',
+          path: undefined,
+        },
+        secondaryHosts: [
+          {
+            baseUrl: 'http://localhost:3001',
+            password: 'password_from_file_2',
+            path: undefined,
+          }
+        ],
+        adList: true,
+        auditLog: false,
+        blacklist: true,
+        client: true,
+        flushTables: true,
+        group: true,
+        localCnameRecords: true,
+        localDnsRecords: true,
+        regexList: true,
+        regexWhitelist: true,
+        staticDhcpLeases: false,
+        whitelist: true,
+        updateGravity: true,
       },
       notify: {
         exceptions: {
@@ -129,7 +136,6 @@ describe('Config', () => {
       },
       intervalMinutes: 60,
       runOnce: false,
-      updateGravity: true,
       verbose: false
     });
   });

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -7,10 +7,11 @@ describe('entrypoint', () => {
 
   beforeEach(() => {
     nock.disableNetConnect();
+    process.env['VERSION'] = 'v5';
     process.env['PRIMARY_HOST_BASE_URL'] = 'http://localhost:3000';
     process.env['PRIMARY_HOST_PASSWORD'] = 'password';
-    process.env['SECONDARY_HOSTS_1_BASE_URL'] = 'http://localhost:3001';
-    process.env['SECONDARY_HOSTS_1_PASSWORD'] = 'password';
+    process.env['SECONDARY_HOST_1_BASE_URL'] = 'http://localhost:3001';
+    process.env['SECONDARY_HOST_1_PASSWORD'] = 'password';
     process.env['RUN_ONCE'] = 'true';
   });
 

--- a/test/unit/notify.test.ts
+++ b/test/unit/notify.test.ts
@@ -52,7 +52,7 @@ describe('Notify', () => {
             baseUrl: 'http://10.0.0.3',
             password: 'password2'
           }
-        ],
+        ]
       },
       verbose: false,
       notify: {

--- a/test/unit/sync.test.ts
+++ b/test/unit/sync.test.ts
@@ -8,7 +8,6 @@ import { ErrorNotification } from '../../src/notify';
 import { Sync } from '../../src/sync';
 import { Version } from '../../src/config/version';
 import { NotifyV5 } from '../../src/notify/v5';
-// import { SyncOptionsV5 } from '../../src/config/index';
 
 describe('sync', () => {
   let clientCreate: ReturnType<typeof jest.spyOn>;
@@ -65,10 +64,10 @@ describe('sync', () => {
       makeBackup: jest.fn(() => primaryResult ?? Promise.resolve(backupData))
     } as unknown as ClientV5;
     secondaryHostClient1 = {
-      restoreBackup: jest.fn(() => secondaryOneResult ?? Promise.resolve(true)),
+      restoreBackup: jest.fn(() => secondaryOneResult ?? Promise.resolve(true))
     } as unknown as ClientV5;
     secondaryHostClient2 = {
-      restoreBackup: jest.fn(() => secondaryTwoResult ?? Promise.resolve(true)),
+      restoreBackup: jest.fn(() => secondaryTwoResult ?? Promise.resolve(true))
     } as unknown as ClientV5;
     clientCreate = jest
       .spyOn(ClientV5, 'create')

--- a/test/unit/sync.test.ts
+++ b/test/unit/sync.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, jest, test } from '@jest/globals';
 import nock from 'nock';
 import { Blob } from 'node-fetch';
 import { ClientV5 } from '../../src/client/v5';
-import { Config } from '../../src/config/index';
+import { Config, ConfigInterfaceV5 } from '../../src/config/index';
 import { Log } from '../../src/log';
-import { ErrorNotification, Notify } from '../../src/notify';
+import { ErrorNotification } from '../../src/notify';
 import { Sync } from '../../src/sync';
-import { SyncOptionsV5 } from '../../src/config/index';
+import { Version } from '../../src/config/version';
+import { NotifyV5 } from '../../src/notify/v5';
+// import { SyncOptionsV5 } from '../../src/config/index';
 
 describe('sync', () => {
   let clientCreate: ReturnType<typeof jest.spyOn>;
@@ -48,25 +50,25 @@ describe('sync', () => {
     secondaryOneResult?: Promise<boolean | never>;
     secondaryTwoResult?: Promise<boolean | never>;
   } = {}) => {
-    const config = Config({
-      primaryHost: primaryHostValue,
-      secondaryHosts: secondaryHostsValue,
-      runOnce: true
+    const config = Config(Version.v5, {
+      sync: {
+        primaryHost: primaryHostValue,
+        secondaryHosts: secondaryHostsValue,
+        runOnce: true
+      }
     });
-    const notify = new Notify(config);
     const log = new Log(config.verbose);
+    const notify = new NotifyV5(config, log);
 
     processExit = jest.spyOn(process, 'exit').mockReturnValue(undefined as never);
     primaryHostClient = {
-      downloadBackup: jest.fn(() => primaryResult ?? Promise.resolve(backupData))
+      makeBackup: jest.fn(() => primaryResult ?? Promise.resolve(backupData))
     } as unknown as ClientV5;
     secondaryHostClient1 = {
-      uploadBackup: jest.fn(() => secondaryOneResult ?? Promise.resolve(true)),
-      updateGravity: jest.fn(() => Promise.resolve(true))
+      restoreBackup: jest.fn(() => secondaryOneResult ?? Promise.resolve(true)),
     } as unknown as ClientV5;
     secondaryHostClient2 = {
-      uploadBackup: jest.fn(() => secondaryTwoResult ?? Promise.resolve(true)),
-      updateGravity: jest.fn(() => Promise.resolve(true))
+      restoreBackup: jest.fn(() => secondaryTwoResult ?? Promise.resolve(true)),
     } as unknown as ClientV5;
     clientCreate = jest
       .spyOn(ClientV5, 'create')
@@ -84,7 +86,7 @@ describe('sync', () => {
     options,
     log
   }: {
-    options: SyncOptionsV5;
+    options: ConfigInterfaceV5;
     log: Log;
   }) => {
     expect(clientCreate).toHaveBeenCalledTimes(3);
@@ -103,19 +105,19 @@ describe('sync', () => {
       options,
       log
     });
-    expect(primaryHostClient.downloadBackup).toHaveBeenCalledTimes(1);
-    expect(secondaryHostClient1.uploadBackup).toHaveBeenCalledTimes(1);
-    expect(secondaryHostClient1.uploadBackup).toHaveBeenCalledWith(backupData);
-    expect(secondaryHostClient2.uploadBackup).toHaveBeenCalledTimes(1);
-    expect(secondaryHostClient2.uploadBackup).toHaveBeenCalledWith(backupData);
+    expect(primaryHostClient.makeBackup).toHaveBeenCalledTimes(1);
+    expect(secondaryHostClient1.restoreBackup).toHaveBeenCalledTimes(1);
+    expect(secondaryHostClient1.restoreBackup).toHaveBeenCalledWith(backupData);
+    expect(secondaryHostClient2.restoreBackup).toHaveBeenCalledTimes(1);
+    expect(secondaryHostClient2.restoreBackup).toHaveBeenCalledWith(backupData);
   };
 
   test('should perform sync and succeed', async () => {
-    const { config, notify, log } = prepare();
+    const { config, log } = prepare();
 
-    await Sync.perform(config, { notify, log });
+    await Sync.perform(config, { log });
 
-    expectSyncToHaveBeenPerformed({ options: config.sync.v5, log });
+    expectSyncToHaveBeenPerformed({ options: config, log });
     expect(notifyOfFailure).not.toHaveBeenCalled();
     expect(notifyQueueError).not.toHaveBeenCalled();
     expect(notifyOfSuccess).toHaveBeenCalledTimes(1);
@@ -126,13 +128,13 @@ describe('sync', () => {
   });
 
   test('should perform sync and partially succeed', async () => {
-    const { config, notify, log } = prepare({
+    const { config, log } = prepare({
       secondaryTwoResult: Promise.reject(new ErrorNotification({ message: 'foobar' }))
     });
 
-    await Sync.perform(config, { notify, log });
+    await Sync.perform(config, { log });
 
-    expectSyncToHaveBeenPerformed({ options: config.sync.v5, log });
+    expectSyncToHaveBeenPerformed({ options: config, log });
     expect(notifyOfSuccess).not.toHaveBeenCalled();
     expect(notifyQueueError).toHaveBeenCalledTimes(1);
     expect(notifyQueueError).toHaveBeenCalledWith(
@@ -149,16 +151,16 @@ describe('sync', () => {
   });
 
   test('should perform sync and fail', async () => {
-    const { config, notify, log } = prepare({
+    const { config, log } = prepare({
       secondaryOneResult: Promise.reject(new ErrorNotification({ message: 'foobar' })),
       secondaryTwoResult: Promise.reject(
         new ErrorNotification({ message: 'hello world' })
       )
     });
 
-    await Sync.perform(config, { notify, log });
+    await Sync.perform(config, { log });
 
-    expectSyncToHaveBeenPerformed({ options: config.sync.v5, log });
+    expectSyncToHaveBeenPerformed({ options: config, log });
     expect(notifyOfSuccess).not.toHaveBeenCalled();
     expect(notifyQueueError).toHaveBeenCalledTimes(2);
     expect(notifyQueueError).toHaveBeenCalledWith(
@@ -179,13 +181,13 @@ describe('sync', () => {
   });
 
   test('should perform sync and fail', async () => {
-    const { config, notify, log } = prepare({
+    const { config, log } = prepare({
       primaryResult: Promise.reject(
         new ErrorNotification({ message: 'Backup failed to download' })
       )
     });
 
-    await Sync.perform(config, { notify, log });
+    await Sync.perform(config, { log });
 
     expect(notifyOfSuccess).not.toHaveBeenCalled();
     expect(notifyQueueError).not.toHaveBeenCalled();
@@ -195,8 +197,8 @@ describe('sync', () => {
         message: 'Backup failed to download'
       })
     );
-    expect(secondaryHostClient1.uploadBackup).not.toHaveBeenCalled();
-    expect(secondaryHostClient2.uploadBackup).not.toHaveBeenCalled();
+    expect(secondaryHostClient1.restoreBackup).not.toHaveBeenCalled();
+    expect(secondaryHostClient2.restoreBackup).not.toHaveBeenCalled();
     expect(processExit).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Motivation: basically everything about the specifics of the config schema that might change with v6 is to be handled by a specific class.

Detail:
Sync does a lot less now - much more in Client and ClientV5.
Slightly cleaner class file paths, but not sure if it should be `x/v5/index.ts` or `x/xv5.ts` e.g. `host/v5/index.js` vs `host/hostv5.ts`
Run out of time today for e2e, integration tests, but want to get eyes on the code first before I pour more time into it in case we want to make large changes here.

To Do:
* gravity unit tests
* unit test coverage of new code
* don't like that I've split notify, but it used specifics of the host configuration 😞 
* arguably the client.create method should move to the factory now
* file envvars are tied to the path of the config key, which means they've changed - I think there should be a better way to do that so this doesn't break existing installs - sort of makes keeping it v5 compatible pointless!
* one of the unit tests fails when run with `yarn run test:unit` but not when run with `NODE_OPTIONS=--experimental-vm-modules yarn jest --runInBand test/unit/`
  ```
  FAIL test/unit/sync.test.ts
    ● Test suite failed to run
  
      Jest worker encountered 4 child process exceptions, exceeding retry limit
  
        at ChildProcessWorker.initialize (node_modules/jest-worker/build/workers/ChildProcessWorker.js:181:21)
  ```
* as above - e2e, integration
* ?