### PR TITLE
chore: update tests to 3 piholes

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@typescript-eslint/eslint-plugin": "^8.0.1",
     "@typescript-eslint/parser": "^8.0.0",
     "commitlint": "^19.2.1",
-    "eslint": "^9.8.0",
+    "eslint": "^9.9.1",
     "eslint-config-prettier": "^9.1.0",
     "jest": "^29.7.0",
     "lefthook": "^1.6.7",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@typescript-eslint/eslint-plugin": "^8.0.1",
     "@typescript-eslint/parser": "^8.0.0",
     "commitlint": "^19.2.1",
-    "eslint": "^9.9.1",
+    "eslint": "^9.8.0",
     "eslint-config-prettier": "^9.1.0",
     "jest": "^29.7.0",
     "lefthook": "^1.6.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orbital-sync",
   "description": "Synchronize multiple Pi-hole instances",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "type": "module",
   "main": "dist/index.js",
   "license": "MIT",

--- a/test/e2e/three-targets.test.ts
+++ b/test/e2e/three-targets.test.ts
@@ -9,12 +9,13 @@ import sleep from 'sleep-promise';
 
 describe('Orbital', () => {
   describe('Alpine', () => {
-    it('should sync two targets and exit with "zero" exit code', async () => {
+    it('should sync three targets and exit with "zero" exit code', async () => {
       const network = await new Network().start();
-      const [pihole1, pihole2, pihole3, orbitalImage] = await Promise.all([
+      const [pihole1, pihole2, pihole3, pihole4, orbitalImage] = await Promise.all([
         createPiholeContainer({ password: 'primary' }).withNetwork(network).start(),
         createPiholeContainer({ password: 'secondary' }).withNetwork(network).start(),
         createPiholeContainer({ password: 'tertiary' }).withNetwork(network).start(),
+        createPiholeContainer({ password: 'quaternary' }).withNetwork(network).start(),
         createOrbitalSyncContainer(OrbitalBaseImage.Alpine)
       ]);
 
@@ -26,6 +27,8 @@ describe('Orbital', () => {
           SECONDARY_HOST_1_PASSWORD: 'secondary',
           SECONDARY_HOST_2_BASE_URL: `http://${pihole3.getIpAddress(network.getName())}`,
           SECONDARY_HOST_2_PASSWORD: 'tertiary',
+          SECONDARY_HOST_3_BASE_URL: `http://${pihole4.getIpAddress(network.getName())}`,
+          SECONDARY_HOST_3_BASE_PASSWORD: 'quaternary',
           RUN_ONCE: 'true',
           VERBOSE: 'true'
         })
@@ -46,12 +49,13 @@ describe('Orbital', () => {
   });
 
   describe('Distroless', () => {
-    it('should sync two targets and exit with "zero" exit code', async () => {
+    it('should sync three targets and exit with "zero" exit code', async () => {
       const network = await new Network().start();
-      const [pihole1, pihole2, pihole3, orbitalImage] = await Promise.all([
+      const [pihole1, pihole2, pihole3, pihole4, orbitalImage] = await Promise.all([
         createPiholeContainer({ password: 'primary' }).withNetwork(network).start(),
         createPiholeContainer({ password: 'secondary' }).withNetwork(network).start(),
         createPiholeContainer({ password: 'tertiary' }).withNetwork(network).start(),
+        createPiholeContainer({ password: 'quaternary' }).withNetwork(network).start(),
         createOrbitalSyncContainer(OrbitalBaseImage.Distroless)
       ]);
 
@@ -63,6 +67,8 @@ describe('Orbital', () => {
           SECONDARY_HOST_1_PASSWORD: 'secondary',
           SECONDARY_HOST_2_BASE_URL: `http://${pihole3.getIpAddress(network.getName())}`,
           SECONDARY_HOST_2_PASSWORD: 'tertiary',
+          SECONDARY_HOST_3_BASE_URL: `http://${pihole4.getIpAddress(network.getName())}`,
+          SECONDARY_HOST_3_PASSWORD: 'quaternary',
           RUN_ONCE: 'true',
           VERBOSE: 'true'
         })


### PR DESCRIPTION
This change updates the E2E test to test for a scenario where there is a primary and 3 "secondary" pihole instances that need to be synced by orbital-sync

See linked discussion: https://github.com/mattwebbio/orbital-sync/discussions/273