### PR TITLE
Added support for listening for an MQTT message to do an “on demand” sync.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ### Changelog
 
+## [1.8.5]
+
+## Features
+* This fork addes feature to listen for MQTT message to trigger a synchronization.  All other functionality remains in place.
+
 
 ## [1.8.4](https://github.com/mattwebbio/orbital-sync/compare/v1.8.3...v1.8.4) (2025-01-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### Changelog
 
-## [1.8.5]
+## [1.8.5] (2025-02-03)
 
 ## Features
 * This fork addes feature to listen for MQTT message to trigger a synchronization.  All other functionality remains in place.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ services:
       SECONDARY_HOSTS_3_BASE_URL: 'http://server:8080'
       SECONDARY_HOSTS_3_PASSWORD: 'your_password4'
       SECONDARY_HOSTS_3_PATH: '/apps/pi-hole'
+      MQTT_BROKER_URL: 'mqtt://optional.url.for.mqtt'
+      MQTT_BROKER_TOPIC: 'orbitalsync/trigger'
       INTERVAL_MINUTES: 60
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+# Briefly
+
+Below is verbatim copy from Matt Webb's repo for this project.  The only addition I have done here is to have hacked in a subrouting that monitor for an MQTT message. 
+My objective was to be able to force an "on demand" sync rather than having to wait for the refresh cycle.
+
+My intention is put a button in my home assistant that sends an MQTT message to force a refresh - or perhaps put a button on a webpage.
+
+I'm sure I have made a mess of things - but I was able to get my docker container to spin up and have tested sending an MQTT message.
+
+
+
+---
+
 [![Website](https://img.shields.io/badge/-Website-lightblue.svg?longCache=true&style=for-the-badge&logo=data:image/svg%2bxml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI0MjAiCmhlaWdodD0iNDIwIiBzdHJva2U9IiMwMDAiIGZpbGw9Im5vbmUiPgo8cGF0aCBzdHJva2Utd2lkdGg9IjI2IgpkPSJNMjA5LDE1YTE5NSwxOTUgMCAxLDAgMiwweiIvPgo8cGF0aCBzdHJva2Utd2lkdGg9IjE4IgpkPSJtMjEwLDE1djM5MG0xOTUtMTk1SDE1TTU5LDkwYTI2MCwyNjAgMCAwLDAgMzAyLDAgbTAsMjQwIGEyNjAsMjYwIDAgMCwwLTMwMiwwTTE5NSwyMGEyNTAsMjUwIDAgMCwwIDAsMzgyIG0zMCwwIGEyNTAsMjUwIDAgMCwwIDAtMzgyIi8+Cjwvc3ZnPg==)](https://orbitalsync.com)
 [![GitHub](https://img.shields.io/badge/-GitHub-lightgrey.svg?longCache=true&style=for-the-badge&logo=github)](https://github.com/mattwebbio/orbital-sync)
 [![GitHub Stars](https://img.shields.io/github/stars/mattwebbio/orbital-sync?style=for-the-badge&logo=github&labelColor=lightgrey&color=lightgrey)](https://github.com/mattwebbio/orbital-sync)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 Below is verbatim copy from Matt Webb's repo for this project.  The only addition I have done here is to have hacked in a subrouting that monitor for an MQTT message. 
 My objective was to be able to force an "on demand" sync rather than having to wait for the refresh cycle.
 
+I have added two lines in the sample docker-compose for environment variables for MQTT_BROKER_URL and TOPIC.
+
 My intention is put a button in my home assistant that sends an MQTT message to force a refresh - or perhaps put a button on a webpage.
 
 I'm sure I have made a mess of things - but I was able to get my docker container to spin up and have tested sending an MQTT message.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Briefly
 
-Below is verbatim copy from Matt Webb's repo for this project.  The only addition I have done here is to have hacked in a subrouting that monitor for an MQTT message. 
+Below is verbatim copy of the README.md from Matt Webb's repo for this project.  The only addition I have done here is to have hacked in a subroutine that will monitor for an MQTT message. 
 My objective was to be able to force an "on demand" sync rather than having to wait for the refresh cycle.
 
 I have added two lines in the sample docker-compose for environment variables for MQTT_BROKER_URL and TOPIC.

--- a/package.json
+++ b/package.json
@@ -60,6 +60,8 @@
     "node-fetch": "^3.3.2",
     "node-html-parser": "^7.0.1",
     "nodemailer": "^6.9.13",
-    "sleep-promise": "^9.1.0"
+    "sleep-promise": "^9.1.0",
+    "mqtt": "^4.3.7"
+
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,18 +2,70 @@
 
 import chalk from 'chalk';
 import sleep from 'sleep-promise';
+import { EventEmitter } from 'events';
+import mqtt from 'mqtt';
 import { Log } from './log.js';
 import { Sync } from './sync.js';
 import { Config } from './config/index.js';
 
+// Load Config
 const config = Config();
 const log = new Log(config.verbose);
 
-do {
-  await Sync.perform(config, { log });
+// Get MQTT settings from environment variables
+const MQTT_BROKER_URL: string | undefined = process.env.MQTT_BROKER_URL;
+const MQTT_TOPIC: string = process.env.MQTT_TOPIC || 'orbitalsync/trigger';
 
-  if (!config.runOnce) {
-    log.info(chalk.dim(`Waiting ${config.intervalMinutes} minutes...`));
-    await sleep(config.intervalMinutes * 60 * 1000);
-  }
+// EventEmitter for external triggers
+const eventEmitter = new EventEmitter();
+
+// Initialize MQTT only if MQTT_BROKER_URL is provided
+let mqttClient: mqtt.MqttClient | null = null;
+
+if (MQTT_BROKER_URL) {
+  mqttClient = mqtt.connect(MQTT_BROKER_URL);
+
+  mqttClient.on('connect', () => {
+    log.info(chalk.blue(`Connected to MQTT broker at ${MQTT_BROKER_URL}`));
+    mqttClient?.subscribe(MQTT_TOPIC, (err) => {
+      if (err) {
+        log.error(chalk.red('Failed to subscribe to MQTT topic!'));
+      } else {
+        log.info(chalk.blue(`Subscribed to MQTT topic: ${MQTT_TOPIC}`));
+      }
+    });
+  });
+
+  mqttClient.on('message', (topic: string, message: Buffer) => {
+    if (topic === MQTT_TOPIC) {
+      log.info(chalk.yellow(`Received MQTT trigger: ${message.toString()}`));
+      eventEmitter.emit('syncNow');
+    }
+  });
+
+  mqttClient.on('error', (err) => {
+    log.error(chalk.red(`MQTT error: ${err.message}`));
+  });
+}
+
+//Main
+(async () => {
+  do {
+    // Initial Sync on startup
+    await Sync.perform(config, { log });
+
+    if (!config.runOnce) {
+      log.info(chalk.dim(`Waiting ${config.intervalMinutes} minutes...`));
+    // Wait for timer to pop or MQTT event to be received
+    await Promise.race([
+    sleep(config.intervalMinutes * 60 * 1000), //wait for interval
+    MQTT_BROKER_URL ? new Promise(resolve => eventEmitter.once('syncNow', resolve)) : Promise.resolve(),
+    ]);}
 } while (!config.runOnce);
+
+
+//Cleanup 
+if (mqttClient) {
+	mqttClient.end();
+}
+})();


### PR DESCRIPTION
# OBJECTIVE

My changes are minor - just added a subroutine to listen for MQTT message (only if MQT_BROKER_URL is defined).  Upon receipt of the message, a sync is fired.

Hopefully this could be of use to the wider community.

